### PR TITLE
новый статус код для del user

### DIFF
--- a/specs/usersapi.spec.js
+++ b/specs/usersapi.spec.js
@@ -51,6 +51,6 @@ describe('Users', () => {
     console.log('удаляем userid', userId)
     console.log(delresponse.status)
     console.log('текст сообщения в теле ответа', delresponse.body)
-    expect(delresponse.status).toBe(204)
+    expect(delresponse.status).toBe(204)//руками вызвала getuser, он отвечает. затем вызвала deluser возращает статус код 204, после чего дернула getuser и он отвечает, что юзер не найден 
   })
 })


### PR DESCRIPTION
пришла к выводу, что в свагере задокументирован неверный статус код для успешного удаления юзера. 
Потому что:
руками вызвала getuser, он отвечает. 
затем вызвала deluser возращает статус код 204, 
после чего дернула getuser и он отвечает, что юзер не найден.